### PR TITLE
fix: Use *bool for EnforceFeatureOwners to allow setting false

### DIFF
--- a/models.go
+++ b/models.go
@@ -17,7 +17,7 @@ type Project struct {
 	FeatureNameRegex               string `json:"feature_name_regex,omitempty"`
 	StaleFlagsLimitDays            int64  `json:"stale_flags_limit_days,omitempty"`
 	EnableRealtimeUpdates          bool   `json:"enable_realtime_updates,omitempty"`
-	EnforceFeatureOwners           bool   `json:"enforce_feature_owners,omitempty"`
+	EnforceFeatureOwners           *bool  `json:"enforce_feature_owners,omitempty"`
 }
 
 type FeatureMultivariateOption struct {

--- a/project_test.go
+++ b/project_test.go
@@ -38,7 +38,8 @@ func TestGetProject(t *testing.T) {
 	assert.Equal(t, ProjectID, project.ID)
 	assert.Equal(t, ProjectUUID, project.UUID)
 	assert.Equal(t, "project-1", project.Name)
-	assert.Equal(t, true, project.EnforceFeatureOwners)
+	assert.NotNil(t, project.EnforceFeatureOwners)
+	assert.Equal(t, true, *project.EnforceFeatureOwners)
 
 }
 
@@ -80,6 +81,38 @@ func TestCreateProjectByUUID(t *testing.T) {
 	assert.Equal(t, "project-1", project.Name)
 
 }
+func TestUpdateProjectEnforceFeatureOwnersFalse(t *testing.T) {
+	// Given
+	enforceOwners := false
+	project := flagsmithapi.Project{
+		ID:                   ProjectID,
+		Name:                 ProjectName,
+		Organisation:         OrganisationID,
+		EnforceFeatureOwners: &enforceOwners,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rawBody, err := io.ReadAll(req.Body)
+		assert.NoError(t, err)
+
+		// Verify false is present in the payload (not omitted)
+		assert.Contains(t, string(rawBody), `"enforce_feature_owners":false`)
+
+		rw.Header().Set("Content-Type", "application/json")
+		_, err = io.WriteString(rw, GetProjectResponseJson)
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	client := flagsmithapi.NewClient(MasterAPIKey, server.URL+"/api/v1")
+
+	// When
+	err := client.UpdateProject(&project)
+
+	// Then
+	assert.NoError(t, err)
+}
+
 func TestUpdateProject(t *testing.T) {
 	// Given
 	project := flagsmithapi.Project{


### PR DESCRIPTION
## Summary
- Change `EnforceFeatureOwners` from `bool` to `*bool` in `Project` struct
- With `bool` + `omitempty`, `false` is the zero value and gets omitted from JSON, making it impossible to disable the setting once enabled
- With `*bool` + `omitempty`, `false` is serialized correctly; only `nil` is omitted

## Test plan
- [x] `TestUpdateProjectEnforceFeatureOwnersFalse` — verifies `false` is present in the request payload
- [x] `TestGetProject` — updated to assert `*bool` deserialization
- [x] All existing tests pass